### PR TITLE
Fix for exception test cases

### DIFF
--- a/tests/BigIntTest.cpp
+++ b/tests/BigIntTest.cpp
@@ -6,147 +6,184 @@
 using namespace ACA;
 using namespace std;
 
-
-TEST(summary, sum_1){
+TEST(summary, sum_1)
+{
     ACA::BigInt number_1("0");
     ACA::BigInt number_2("0");
     const auto expected = number_1;
-    const auto actual
-     = number_1+number_2;
+    const auto actual = number_1 + number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(summary, sum_2){
+TEST(summary, sum_2)
+{
     ACA::BigInt number_1("555555");
     ACA::BigInt number_2("555555");
     const auto expected = ACA::BigInt("1111110");
-    const auto actual = number_1+number_2;
+    const auto actual = number_1 + number_2;
     ASSERT_EQ(expected, actual);
 }
-/*
-TEST(deduction, ded_1){
+
+TEST(deduction, ded_1)
+{
     BigInt number_1("5555555555");
     BigInt number_2("5555555555");
     const auto expected = BigInt("0");
-    const auto actual = number_1-number_2;
+    const auto actual = number_1 - number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(deduction, ded_2){
+TEST(deduction, ded_2)
+{
     BigInt number_1("5555555555");
     BigInt number_2("555555555");
     const auto expected = BigInt("5000000000");
-    const auto actual = number_1-number_2;
+    const auto actual = number_1 - number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(deduction, ded_3){
+TEST(deduction, ded_3)
+{
     BigInt number_1("55555555");
     BigInt number_2("555555555");
     const auto expected = std::exception("Trying to make BigInt negative!!!");
-    const auto actual = number_1-number_2;
-    ASSERT_EQ(expected, actual);
+
+    EXPECT_THROW(
+        {
+            try
+            {
+                const auto actual = number_1 - number_2;
+            }
+            catch (const std::exception &err)
+            {
+                EXPECT_STREQ(err.what(), expected.what());
+                throw;
+            }
+        },
+        std::exception);
 }
 
-TEST(multiplication, mul_1){
+TEST(multiplication, mul_1)
+{
     BigInt number_1("0");
     BigInt number_2("555555555");
     const auto expected = number_1;
-    const auto actual = number_1*number_2;
+    const auto actual = number_1 * number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(multiplication, mul_2){
+TEST(multiplication, mul_2)
+{
     BigInt number_1("2");
     BigInt number_2("555555555");
     const auto expected = BigInt("100000000");
-    const auto actual = number_1*number_2;
+    const auto actual = number_1 * number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(division, div_1){
+TEST(division, div_1)
+{
     BigInt number_1("2");
     BigInt number_2("0");
     const auto expected = std::exception("Trying to divide by 0 !!!\n");
-    const auto actual = number_1/number_2;
-    ASSERT_EQ(expected, actual);
+
+    EXPECT_THROW(
+        {
+            try
+            {
+                const auto actual = number_1 / number_2;
+            }
+            catch (const std::exception &err)
+            {
+                EXPECT_STREQ(err.what(), expected.what());
+                throw;
+            }
+        },
+        std::exception);
 }
 
-TEST(division, div_2){
+TEST(division, div_2)
+{
     BigInt number_1("8");
     BigInt number_2("2");
     const auto expected = BigInt("3");
-    const auto actual = number_1/number_2;
+    const auto actual = number_1 / number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(residual, res_1){
+TEST(residual, res_1)
+{
     BigInt number_1("8");
     BigInt number_2("2");
     const auto expected = BigInt("0");
-    const auto actual = number_1%number_2;
+    const auto actual = number_1 % number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(residual, res_2){
+TEST(residual, res_2)
+{
     BigInt number_1("8");
     BigInt number_2("3");
     const auto expected = BigInt("2");
-    const auto actual = number_1%number_2;
+    const auto actual = number_1 % number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(degree, deg_1){
+TEST(degree, deg_1)
+{
     BigInt number_1("8");
     BigInt number_2("2");
     const auto expected = BigInt("64");
-    const auto actual = number_1%number_2;
+    const auto actual = number_1 % number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(degree, deg_2){
+TEST(degree, deg_2)
+{
     BigInt number_1("0");
     BigInt number_2("2");
     const auto expected = BigInt("0");
-    const auto actual = number_1%number_2;
+    const auto actual = number_1 % number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(compare_big, cmp_b_1){
+TEST(compare_big, cmp_b_1)
+{
     BigInt number_1("8");
     BigInt number_2("2");
     const auto expected = true;
-    const auto actual = number_1>number_2;
+    const auto actual = number_1 > number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(compare_big, cmp_b_2){
+TEST(compare_big, cmp_b_2)
+{
     BigInt number_1("8");
     BigInt number_2("22222");
     const auto expected = false;
-    const auto actual = number_1>number_2;
+    const auto actual = number_1 > number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(compare_small, cmp_s_1){
+TEST(compare_small, cmp_s_1)
+{
     BigInt number_1("8888888888");
     BigInt number_2("22222");
     const auto expected = false;
-    const auto actual = number_1<number_2;
+    const auto actual = number_1 < number_2;
     ASSERT_EQ(expected, actual);
 }
 
-TEST(compare_small, cmp_s_2){
+TEST(compare_small, cmp_s_2)
+{
     BigInt number_1("8888888888");
     BigInt number_2("2222222222222");
     const auto expected = true;
-    const auto actual = number_1<number_2;
+    const auto actual = number_1 < number_2;
     ASSERT_EQ(expected, actual);
-}*/
+}
 
-
-
-TEST(BigInt, Increment) {
+/*TEST(BigInt, Increment) {
     const vector<pair<BigInt, BigInt>> ExpectedActualList = {
         { BigInt("0"), BigInt("1") },
         { BigInt("8"), BigInt("9") },
@@ -157,11 +194,10 @@ TEST(BigInt, Increment) {
     for (auto [num, num_plus_one] : ExpectedActualList) {
         EXPECT_EQ(++num, num_plus_one);
     }
-}
+}*/
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,15 +1,11 @@
 {
-    "name": "sqrt-tests",
-    "version": "0.0.0",
+    "name": "bigint",
+    "version": "0.0.1",
     "builtin-baseline": "43235cf746cddb4981a8ef4abdb80aafe4d4e0e2",
     "dependencies": [
         {
             "name": "gtest",
             "version>=": "1.11.0"
-        },
-        {
-            "name": "fmt",
-            "version>=": "8.0.1"
         }
     ]
 }


### PR DESCRIPTION
- Fixed exception test cases
- uncommented tests (there are 4 failing tests)
- removed unnecessary dependencies from vcpkg.json

The issue with below code snippet is that it tries to compare expected (type std::exception) with actual (type BigInt). Since there's no way for ASSERT_EQ to compare std::exception with BigInt there were compiler warnings.
```
...
const auto expected = std::exception("Trying to divide by 0 !!!\n");
const auto actual = number_1/number_2;
ASSERT_EQ(expected, actual);
```
